### PR TITLE
Feature/add gbp conversion to sale price

### DIFF
--- a/forms/createTrack.tsx
+++ b/forms/createTrack.tsx
@@ -21,7 +21,7 @@ export default function CreateReleaseForm({
   const { address } = useWalletStore();
   const [showRoyalties, setShowRoyalties] = useState<boolean>(false);
   const [showStakeholders, setShowStakeholders] = useState<boolean>(false);
-  const [dollarPrice, setDollarPrice] = useState<number>(0);
+  const [GBPPrice, setGBPPrice] = useState<number>(0);
 
   const emailRequired = t("email.required");
   const emailValid = t("email.valid");
@@ -77,7 +77,7 @@ export default function CreateReleaseForm({
   useEffect(() => {
     fetch("https://api.coingecko.com/api/v3/simple/price?ids=matic-network&vs_currencies=gbp")
       .then((res) => res.json())
-      .then((res) => setDollarPrice(res["matic-network"].gbp));
+      .then((res) => setGBPPrice(res["matic-network"].gbp));
 
     if (address) {
       reset({
@@ -90,8 +90,8 @@ export default function CreateReleaseForm({
   const symbolValue = watch("symbol");
   const salePriceValue = watch("salePrice");
 
-  const currencyConversion = Boolean(salePriceValue && dollarPrice)
-    ? `(£${(salePriceValue * dollarPrice).toFixed(2)})`
+  const currencyConversion = Boolean(salePriceValue && GBPPrice)
+    ? `(£${(salePriceValue * GBPPrice).toFixed(2)})`
     : "(£0.00)";
 
   return (

--- a/forms/createTrack.tsx
+++ b/forms/createTrack.tsx
@@ -21,6 +21,7 @@ export default function CreateReleaseForm({
   const { address } = useWalletStore();
   const [showRoyalties, setShowRoyalties] = useState<boolean>(false);
   const [showStakeholders, setShowStakeholders] = useState<boolean>(false);
+  const [dollarPrice, setDollarPrice] = useState<number>(0);
 
   const emailRequired = t("email.required");
   const emailValid = t("email.valid");
@@ -74,6 +75,10 @@ export default function CreateReleaseForm({
   } = form;
 
   useEffect(() => {
+    fetch("https://api.coingecko.com/api/v3/simple/price?ids=matic-network&vs_currencies=gbp")
+      .then((res) => res.json())
+      .then((res) => setDollarPrice(res["matic-network"].gbp));
+
     if (address) {
       reset({
         stakeholders: [{ address, share: 100 }],
@@ -83,6 +88,11 @@ export default function CreateReleaseForm({
   }, [address]);
 
   const symbolValue = watch("symbol");
+  const salePriceValue = watch("salePrice");
+
+  const currencyConversion = Boolean(salePriceValue && dollarPrice)
+    ? `(£${(salePriceValue * dollarPrice).toFixed(2)})`
+    : "(£0.00)";
 
   return (
     <FormProvider {...form}>
@@ -160,15 +170,16 @@ export default function CreateReleaseForm({
           </Field>
           <Field
             className="col-span-6 lg:col-span-3"
-            helpText="How much does each release cost."
+            helpText="How much does each release cost in MATIC."
             error={errors.salePrice?.message}
           >
             <Input
               name="salePrice"
+              type="number"
               label="Sale Price"
               error={errors.salePrice?.message}
               placeholder="0.5"
-              trailing="MATIC"
+              trailing={`MATIC ${currencyConversion}`}
             />
           </Field>
           <Field className="col-span-6 lg:col-span-3">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -35,4 +35,9 @@
   .gradient-primary-text {
     @apply bg-gradient-to-r from-purple-500 to-pink-500 bg-clip-text text-transparent;
   }
+  input[type="number"]::-webkit-inner-spin-button,
+  input[type="number"]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 }


### PR DESCRIPTION
## Description
This PR adds the MATIC/GBP conversion in the `salePrice` input.

## Checklist
- [x] Fetch MATIC/GBP price from coingecko
- [x] Globally hide input number spinners

## Video
https://user-images.githubusercontent.com/7047410/155279792-e5838712-b6c8-4ba6-9904-a81451ecad9d.mp4


