### PR TITLE
Add ugly error states

### DIFF
--- a/components/field.tsx
+++ b/components/field.tsx
@@ -13,8 +13,8 @@ export default function Field({ children, className, error, helpText }: FieldPro
 
       <p
         className={classNames(
-          error ? "text-black" : "text-black-500",
-          "mt-2 text-sm font-semibold"
+          error ? "bg-red-500  text-white shadow" : "text-black-500 ",
+          "mt-2 rounded-md p-2 text-xs font-semibold"
         )}
       >
         {error ?? helpText}

--- a/forms/createTrack.tsx
+++ b/forms/createTrack.tsx
@@ -237,7 +237,9 @@ export default function CreateReleaseForm({
               })}
               <Field className="col-span-6">
                 {errors?.stakeholders && (
-                  <p className="text-sm font-semibold text-black">{errors.stakeholders.message}</p>
+                  <p className="rounded-md bg-red-500 p-2 text-xs font-semibold">
+                    {errors.stakeholders.message}
+                  </p>
                 )}
               </Field>
               <Field className="col-span-6">
@@ -256,11 +258,7 @@ export default function CreateReleaseForm({
           </div>
         )}
         <Field className="my-5">
-          {!isLoading && (
-            <Button isLoading={isLoading} disabled={!requiredFilesAdded}>
-              Create Track
-            </Button>
-          )}
+          {!isLoading && <Button isLoading={isLoading}>Create Track</Button>}
           {!requiredFilesAdded && (
             <p className="mt-2 text-sm">You're missing an audio file and track artwork.</p>
           )}


### PR DESCRIPTION
## Description
The required error states were not obvious enough. 

## Checklist
- [x] Make error states ugly AF.

## Images
<img width="1552" alt="Screenshot 2022-02-28 at 09 12 12" src="https://user-images.githubusercontent.com/7047410/155956201-ac36b647-3a02-45be-be02-a6cadd5218ef.png">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201874285867910